### PR TITLE
SATS-MINI external trigger for engaging failsafe

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -55,6 +55,13 @@ then
 	fi
 fi
 
+# SATS-MINI
+if param compare SATS_MINI_EN 1
+then
+	pwm_input start
+fi
+
+# SMBus enabled smart battery
 if param compare SENS_EN_BATT 1
 then
 	batt_smbus start -X

--- a/ROMFS/px4fmu_common/init.d/rcS
+++ b/ROMFS/px4fmu_common/init.d/rcS
@@ -366,6 +366,13 @@ else
 		set AUX_MODE pwm4
 	fi
 
+	if param compare SATS_MINI_EN 1
+	then
+		# Clear pins 5 and 6.
+		set FMU_MODE pwm4
+		set AUX_MODE pwm4
+	fi
+
 	if param greater TRIG_MODE 0
 	then
 		# We ONLY support trigger on pins 5 and 6 when simultanously using AUX for actuator output.

--- a/src/modules/commander/commander_params.c
+++ b/src/modules/commander/commander_params.c
@@ -918,3 +918,25 @@ PARAM_DEFINE_INT32(COM_ASPD_FS_DLY, 0);
  * @group Commander
  */
 PARAM_DEFINE_INT32(COM_KILL_DISARM, 0);
+
+/**
+ * Enable PWM input for engaging failsafe from a SATS-MINI.
+ *
+ * If...
+ *
+ * @boolean
+ * @reboot_required true
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(SATS_MINI_EN, 0);
+
+/**
+ * PWM trigger threshold for engaging failsafe.
+ *
+ * If...
+ *
+ * @boolean
+ * @reboot_required true
+ * @group Commander
+ */
+PARAM_DEFINE_INT32(SATS_MINI_TRIG, 1990);

--- a/src/modules/commander/failure_detector/FailureDetector.hpp
+++ b/src/modules/commander/failure_detector/FailureDetector.hpp
@@ -52,12 +52,14 @@
 #include <uORB/topics/vehicle_attitude_setpoint.h>
 #include <uORB/topics/vehicle_attitude.h>
 #include <uORB/topics/vehicle_status.h>
+#include <uORB/topics/pwm_input.h>
 
 typedef enum {
 	FAILURE_NONE = vehicle_status_s::FAILURE_NONE,
 	FAILURE_ROLL = vehicle_status_s::FAILURE_ROLL,
 	FAILURE_PITCH = vehicle_status_s::FAILURE_PITCH,
 	FAILURE_ALT = vehicle_status_s::FAILURE_ALT,
+	FAILURE_EXTERNAL,
 } failure_detector_bitmak;
 
 using uORB::Subscription;
@@ -75,14 +77,21 @@ private:
 
 	DEFINE_PARAMETERS(
 		(ParamInt<px4::params::FD_FAIL_P>) _param_fd_fail_p,
-		(ParamInt<px4::params::FD_FAIL_R>) _param_fd_fail_r
+		(ParamInt<px4::params::FD_FAIL_R>) _param_fd_fail_r,
+		(ParamInt<px4::params::SATS_MINI_EN>) _param_sats_mini_en,
+		(ParamInt<px4::params::SATS_MINI_TRIG>) _param_sats_mini_trig
 	)
 
 	// Subscriptions
 	Subscription<vehicle_attitude_s> _sub_vehicle_attitude_setpoint;
 	Subscription<vehicle_attitude_s> _sub_vehicule_attitude;
+	Subscription<pwm_input_s> _sub_pwm_input;
+
 
 	uint8_t _status{FAILURE_NONE};
 
 	bool update_attitude_status();
+
+	bool update_external_trigger_status();
+
 };


### PR DESCRIPTION
- Added `uORB` publication to the **pwm_input** module. 
- Added a parameter to enable *pwm_input** module and logic in **rcS** to start the module and reassign IO for `fmu`. 
- Added logic to commander to subsribe to **pwm_input** and engage failsafe if the pwm threshold is exceeded.

There are two new parameters:

**SATS_MINI_EN**
This needs to be set to 1. You need to connect the PWM output trigger pin from the SATS-MINI to AUX5 of the Pixhawk (FMU OUT pin 5)

**SATS_MINI_TRIG**
This parameter is the pulse width threshold. SATS-MINI documentation says the output will be 2000us. I would probably set this slightly lower than the threshold, to give some tolerance (real world isn't perfect), like 1990 or something.

